### PR TITLE
Fix: Copyright date

### DIFF
--- a/src/components/sections/Contact.tsx
+++ b/src/components/sections/Contact.tsx
@@ -202,7 +202,7 @@ const Contact = () => {
       </div>
       
       <div className="flex justify-center mt-8 pb-20">
-        Copyright © 2024 Keyyard
+        Copyright © 2025 Keyyard
       </div>
     </section>
   );


### PR DESCRIPTION
# Advance Temporal Fidelity: Update Footer Copyright to 2025

## Summary

This pull request makes a single, surgical change: it updates the footer notice from “Copyright © 2024 Keyyard” to “Copyright © 2025 Keyyard”. The code diff is microscopic, but the informational signal it transmits is significant. On the contemporary web, small, verifiable cues serve as proxies for care, activity, and credibility. This adjustment restores temporal fidelity across the portfolio and ensures that human readers, automated systems, and the general vibe economy all converge on the same conclusion: Keyyard is present, current, and paying attention.

## Background

Before the internet, keeping information fresh was a logistical and economic challenge. A timetable was accurate until a train company issued a new edition; a textbook was authoritative until the next printing introduced a cascade of errata. The mere act of updating required material effort—ink, paper, distribution—and so “out of date” was not a moral failing but an infrastructural reality. Accuracy was expensive and slow.

The World Wide Web inverted those economics. Tim Berners-Lee’s read/write medium lowered the marginal cost of updating to approximately zero, which transformed recency from a rare luxury into an expected property of information. In this environment, users and systems began to rely on small affordances—headers that mention “Last updated,” changelogs with a recent timestamp, and yes, the footer year—as heuristics for whether anyone is home. The footer year, while not legally determinative in many jurisdictions, is a remarkably durable cultural artifact: a succinct, widely understood status light.

## Why Factual Correctness Matters, Even in the Footer

Visitors read the entire page, not just the hero text. The footer is content, and content can be right or wrong. When it is wrong in an obvious way, it compels unnecessary cognitive work. A reader who sees “© 2024” in mid-2025 experiences a microsecond of dissonance and must decide whether the portfolio is a living document or a relic. That moment—however fleeting—competes with the message Keyyard wants to deliver: skill, taste, and momentum. Correcting the year removes that friction and reinforces the narrative that details are respected.

## Academic Parallels: Recency as a Signal of Rigor

In academic research, currency is baked into evaluation. Literature reviews are judged not only by the quality of citations but by their timeliness. A bibliography that ends abruptly a year too early raises questions about whether the researcher surveyed the full landscape. Although Keyyard’s portfolio is not a journal article, evaluators import the same pattern-matching. A current footer subtly signals that the artifact has not been abandoned to the archive but is part of an ongoing practice.

## Accessibility: First Contact and the Cost of Attention

For many users, especially those employing assistive technologies, the structure of a page functions as a navigational map. It is common to skim landmarks to decide whether a deeper read is warranted. When the copyright year appears in a consistent, programmatically discernible location, it provides a quick, low-effort way to assess recency before investing attention. A correctly updated year therefore improves the first-contact experience. As a future refinement, rendering the year with a semantic time element and a machine-readable datetime would allow screen readers and crawlers to parse the information even more reliably, but the immediate win is simply aligning the visible text with reality.

## Employment Optics: The Power of Small Details

Recruiters and collaborators are busy. They thin-slice. In a world of many qualified candidates, minor imperfections can tilt a decision at the margins. A current footer year is not a portfolio’s headline achievement, but it is a non-verbal proof-of-life that helps everything else read more credibly. It communicates that Keyyard tends to the edges of the experience, which is where professionalism often reveals itself. A site that looks lived-in, even in its legalese, is easier to trust than one that appears mothballed.

## Aura and the Gen‑Z Attention Economy

Aura, in this context, is the felt coherence of a presence: the alignment between what a creator says, what their touchpoints convey, and the temporal now in which an audience encounters them. Gen‑Z, more than most cohorts, is exquisitely sensitive to whether something is actively curated or passively decaying. An outdated footer reads as “museum mode”—the energy of an artifact to be looked at rather than a practice to be engaged with. Updating the year restores “studio mode,” the sense that work is ongoing and the creator is in the room. The change is tiny, but the vibe tax for failing to make it is real.

## The Actual Change

The modification is straightforward: every instance of “© 2024 Keyyard” is updated to “© 2025 Keyyard.” If there are multiple surfaces—HTML templates, shared components, static text in a PDF résumé, or JSON‑LD structured data—they are brought into alignment so that the site speaks with one temporal voice. No layout, asset, or dependency changes are introduced.

## Implementation Notes

If the site currently hard-codes the year, the change is a direct edit and a redeploy. If the year is injected at runtime via client-side JavaScript, consider moving that logic to the server or build step to avoid rendering a stale value during initial paint in low‑JS environments. If the site uses a range convention, updating to “© 20XX–2025 Keyyard” can preserve a sense of tenure while maintaining accuracy. Regardless of approach, consistency across all render paths matters more than any particular mechanism.

## Verification and Testing

Validation focuses on presence, consistency, and accessibility. After the change, the footer should present 2025 across all themes, breakpoints, and routes, including error pages and print styles. Where snapshots or visual regression tests exist, their fixtures should be refreshed to reflect the new text. A pass with assistive technology should confirm that the element is reachable, readable, and announced as expected. Finally, a quick search across the repository and any linked assets should verify that no references to the 2024 notice remain.

## Risks and Mitigations

The primary risk is partial application, where one surface updates while another lags. This can be mitigated by a comprehensive search of the codebase and associated assets, including PDFs and metadata files that may not receive frequent attention. Another subtle risk appears at the December–January boundary, where caches or long‑lived CDNs may briefly serve stale content. Proactive cache invalidation at deploy time ensures that the new year propagates promptly.

## Alternatives Considered

A range format such as “© 2019–2025 Keyyard” reinforces continuity of authorship and has the virtue of not resetting annually, though it does still require an update at the high end. A purely dynamic approach that reads the system clock guarantees freshness but adds avoidable complexity if it depends on client-side execution; server-side rendering or a build-time token is safer and more predictable. Omitting the year entirely eliminates the maintenance point but forfeits a widely understood cue that users rely on to judge recency.

## Legal Nuance (Not Legal Advice)

Jurisdictions vary, but modern copyright protection does not generally depend on the presence or annual update of the notice. Nonetheless, the convention of displaying the year has evolved into a de facto freshness signal. Aligning that signal with the current calendar reduces ambiguity for human readers without creating legal downside.

## Performance, Caching, and Operations

From a performance standpoint, the change is effectively neutral. The HTML compresses identically and no new assets are introduced. Operationally, however, it is a valuable chance to verify that cache invalidation behaves as expected, particularly if the footer is part of a shared layout served through a CDN with aggressive TTLs. A clean deploy with explicit purge ensures that the new year is reflected promptly for all visitors.

## SEO and Discoverability

Search engines infer freshness from a constellation of signals rather than any single indicator. The footer year is unlikely to move rankings on its own, but it acts as a corroborating detail in the overall story the site tells about its maintenance cadence. More importantly, it avoids a small contradiction—new content paired with an old legal line—that can erode human trust even when machines remain indifferent.

## Future Enhancements

There are sensible, optional follow‑ups if desired. Introducing a semantic time element for the footer date would make the notice more machine-readable. Unifying all visible dates—résumé footer, JSON‑LD “dateModified,” and Open Graph tags—would present a coherent temporal model to both users and crawlers. Adding a lightweight “Last updated” label in a visible location could provide an explicit recency signal without promising a rigid publishing schedule.

## Success Criteria

Success looks like a portfolio that reads as present and cared-for. Every public surface shows “© 2025 Keyyard,” no stray 2024 references remain, and the overall impression is that the site is alive. Informally, this should reduce the fraction of viewers who wonder whether the portfolio is current and increase the likelihood that the work itself receives undivided attention.

## Non‑Goals

This pull request does not modify projects, design, or copy beyond the year. It does not introduce dynamic infrastructure for dates or alter legal terms. It is a precise, minimal intervention intended to realign presentation with reality.

## Conclusion

The web rewards care at the edges. Updating a single digit in the footer seems trivial, yet it participates in a broader economy of trust where small truths accumulate into credibility. By advancing the copyright notice to 2025, Keyyard’s portfolio affirms its own present tense, improves first impressions for humans and machines, and restores the subtle but consequential aura of a site that is actively stewarded.