### PR TITLE
seo: fix H1 keywords, meta description, JSON-LD, robots tag

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -8,3 +8,15 @@ canvas {
   height: 100%;
   display: absolute ;
 }
+/* Screen-reader only — visually hidden but readable by search engines and assistive tech */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/src/App.css
+++ b/src/App.css
@@ -6,7 +6,7 @@
 canvas {
   width: 100%;
   height: 100%;
-  display: absolute ;
+  display: absolute;
 }
 /* Screen-reader only — visually hidden but readable by search engines and assistive tech */
 .sr-only {

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -65,7 +65,10 @@ const Hero = memo(() => {
 
         {/* Pixel name */}
         <div style={{ textAlign: "center", marginBottom: 8 }}>
-          <h1 className="pixel-name" data-text={heroData.pixelName}>{heroData.pixelName}</h1>
+          <h1 className="pixel-name" data-text={heroData.pixelName}>
+            {heroData.pixelName}
+            <span className="sr-only"> — Minecraft Bedrock Developer, iOS Engineer &amp; Microsoft Marketplace Partner</span>
+          </h1>
         </div>
 
         {/* Role badge */}

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -25,39 +25,110 @@ const Hero = memo(() => {
         aria-hidden="true"
         style={{
           position: "absolute",
-          top: "30%", left: "50%",
+          top: "30%",
+          left: "50%",
           transform: "translate(-50%, -50%)",
-          width: "700px", height: "400px",
-          background: "radial-gradient(ellipse, rgba(93,138,60,0.12) 0%, rgba(78,205,196,0.04) 45%, transparent 70%)",
+          width: "700px",
+          height: "400px",
+          background:
+            "radial-gradient(ellipse, rgba(93,138,60,0.12) 0%, rgba(78,205,196,0.04) 45%, transparent 70%)",
           pointerEvents: "none",
           zIndex: 0,
         }}
       />
 
       {/* Floating blocks */}
-      <div className="floating-blocks" aria-hidden="true" style={{ position: "absolute", inset: 0, pointerEvents: "none", overflow: "hidden", zIndex: 0 }}>
+      <div
+        className="floating-blocks"
+        aria-hidden="true"
+        style={{
+          position: "absolute",
+          inset: 0,
+          pointerEvents: "none",
+          overflow: "hidden",
+          zIndex: 0,
+        }}
+      >
         {Array.from({ length: heroData.floatingBlocksCount }).map((_, i) => (
           <div key={i} className="float-block" />
         ))}
       </div>
 
       {/* Corner block decorations */}
-      <div aria-hidden="true" style={{ position: "absolute", top: 24, left: 24, display: "flex", gap: 4, zIndex: 1, pointerEvents: "none" }}>
+      <div
+        aria-hidden="true"
+        style={{
+          position: "absolute",
+          top: 24,
+          left: 24,
+          display: "flex",
+          gap: 4,
+          zIndex: 1,
+          pointerEvents: "none",
+        }}
+      >
         {heroData.cornerBlocks.topLeft.map((bg, i) => (
-          <div key={i} style={{ width: 18, height: 18, background: bg, opacity: 0.5, clipPath: "polygon(0 2px,2px 0,calc(100% - 2px) 0,100% 2px,100% calc(100% - 2px),calc(100% - 2px) 100%,2px 100%,0 calc(100% - 2px))" }} />
+          <div
+            key={i}
+            style={{
+              width: 18,
+              height: 18,
+              background: bg,
+              opacity: 0.5,
+              clipPath:
+                "polygon(0 2px,2px 0,calc(100% - 2px) 0,100% 2px,100% calc(100% - 2px),calc(100% - 2px) 100%,2px 100%,0 calc(100% - 2px))",
+            }}
+          />
         ))}
       </div>
-      <div aria-hidden="true" style={{ position: "absolute", top: 24, right: 24, display: "flex", gap: 4, zIndex: 1, pointerEvents: "none" }}>
+      <div
+        aria-hidden="true"
+        style={{
+          position: "absolute",
+          top: 24,
+          right: 24,
+          display: "flex",
+          gap: 4,
+          zIndex: 1,
+          pointerEvents: "none",
+        }}
+      >
         {heroData.cornerBlocks.topRight.map((bg, i) => (
-          <div key={i} style={{ width: 18, height: 18, background: bg, opacity: 0.5, clipPath: "polygon(0 2px,2px 0,calc(100% - 2px) 0,100% 2px,100% calc(100% - 2px),calc(100% - 2px) 100%,2px 100%,0 calc(100% - 2px))" }} />
+          <div
+            key={i}
+            style={{
+              width: 18,
+              height: 18,
+              background: bg,
+              opacity: 0.5,
+              clipPath:
+                "polygon(0 2px,2px 0,calc(100% - 2px) 0,100% 2px,100% calc(100% - 2px),calc(100% - 2px) 100%,2px 100%,0 calc(100% - 2px))",
+            }}
+          />
         ))}
       </div>
 
       {/* All content centered */}
-      <div style={{ position: "relative", zIndex: 2, display: "flex", flexDirection: "column", alignItems: "center", width: "100%" }}>
-
+      <div
+        style={{
+          position: "relative",
+          zIndex: 2,
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          width: "100%",
+        }}
+      >
         {/* Block row above name */}
-        <div aria-hidden="true" style={{ display: "flex", gap: 6, marginBottom: 20, animation: "fadeUp 0.5s ease 0.1s both" }}>
+        <div
+          aria-hidden="true"
+          style={{
+            display: "flex",
+            gap: 6,
+            marginBottom: 20,
+            animation: "fadeUp 0.5s ease 0.1s both",
+          }}
+        >
           {heroData.blockRow.map((cls, i) => (
             <div key={i} className={`block-mc ${cls}`} />
           ))}
@@ -67,7 +138,11 @@ const Hero = memo(() => {
         <div style={{ textAlign: "center", marginBottom: 8 }}>
           <h1 className="pixel-name" data-text={heroData.pixelName}>
             {heroData.pixelName}
-            <span className="sr-only"> — Minecraft Bedrock Developer, iOS Engineer &amp; Microsoft Marketplace Partner</span>
+            <span className="sr-only">
+              {" "}
+              — Minecraft Bedrock Developer, iOS Engineer &amp; Microsoft
+              Marketplace Partner
+            </span>
           </h1>
         </div>
 
@@ -82,10 +157,26 @@ const Hero = memo(() => {
         </div>
 
         {/* Impact stats */}
-        <div role="list" className="stat-cards-row" style={{ marginBottom: 52, animation: "fadeUp 0.7s ease 0.7s both" }}>
+        <div
+          role="list"
+          className="stat-cards-row"
+          style={{ marginBottom: 52, animation: "fadeUp 0.7s ease 0.7s both" }}
+        >
           {heroData.statCards.map((card, i) => (
-            <div className={`stat-card ${card.cssClass}`} role="listitem" title={card.title} key={i}>
-              <div className="stat-block-icon" style={{ background: card.blockBg, boxShadow: card.blockShadow }} aria-hidden="true" />
+            <div
+              className={`stat-card ${card.cssClass}`}
+              role="listitem"
+              title={card.title}
+              key={i}
+            >
+              <div
+                className="stat-block-icon"
+                style={{
+                  background: card.blockBg,
+                  boxShadow: card.blockShadow,
+                }}
+                aria-hidden="true"
+              />
               <div style={{ display: "flex", flexDirection: "column" }}>
                 <div className="stat-num">{card.num}</div>
                 <div className="stat-label">{card.label}</div>
@@ -95,19 +186,50 @@ const Hero = memo(() => {
         </div>
 
         {/* Featured project callout */}
-        <a href={heroData.featuredCallout.link} className="featured-callout" style={{ marginBottom: 52 }}>
+        <a
+          href={heroData.featuredCallout.link}
+          className="featured-callout"
+          style={{ marginBottom: 52 }}
+        >
           <div className="featured-label">{heroData.featuredCallout.label}</div>
-          <div style={{ fontFamily: "var(--font-primary)", fontSize: "1.1rem", fontWeight: 700, color: "var(--text-main)", marginBottom: 6 }}>
+          <div
+            style={{
+              fontFamily: "var(--font-primary)",
+              fontSize: "1.1rem",
+              fontWeight: 700,
+              color: "var(--text-main)",
+              marginBottom: 6,
+            }}
+          >
             {heroData.featuredCallout.title}
           </div>
-          <div style={{ fontSize: "0.88rem", color: "var(--text-dim)", lineHeight: 1.6 }}>
-            <span dangerouslySetInnerHTML={{ __html: heroData.featuredCallout.description }} />
+          <div
+            style={{
+              fontSize: "0.88rem",
+              color: "var(--text-dim)",
+              lineHeight: 1.6,
+            }}
+          >
+            <span
+              dangerouslySetInnerHTML={{
+                __html: heroData.featuredCallout.description,
+              }}
+            />
           </div>
           <div className="featured-arrow">▶</div>
         </a>
 
         {/* CTA buttons */}
-        <div style={{ display: "flex", flexWrap: "wrap", gap: 16, justifyContent: "center", marginBottom: 48, animation: "fadeUp 0.7s ease 1.1s both" }}>
+        <div
+          style={{
+            display: "flex",
+            flexWrap: "wrap",
+            gap: 16,
+            justifyContent: "center",
+            marginBottom: 48,
+            animation: "fadeUp 0.7s ease 1.1s both",
+          }}
+        >
           {heroData.ctaButtons.map((btn, i) => (
             <button
               key={i}
@@ -120,8 +242,24 @@ const Hero = memo(() => {
         </div>
 
         {/* XP bar */}
-        <div style={{ width: "100%", maxWidth: 420, textAlign: "center", animation: "fadeUp 0.6s ease 1.3s both" }}>
-          <div style={{ fontFamily: "var(--font-headings)", fontSize: "0.45rem", color: "var(--text-muted)", letterSpacing: "0.15em", marginBottom: 6, textTransform: "uppercase" }}>
+        <div
+          style={{
+            width: "100%",
+            maxWidth: 420,
+            textAlign: "center",
+            animation: "fadeUp 0.6s ease 1.3s both",
+          }}
+        >
+          <div
+            style={{
+              fontFamily: "var(--font-headings)",
+              fontSize: "0.45rem",
+              color: "var(--text-muted)",
+              letterSpacing: "0.15em",
+              marginBottom: 6,
+              textTransform: "uppercase",
+            }}
+          >
             {heroData.xpBar.label}
           </div>
           <div className="xp-track">
@@ -132,11 +270,18 @@ const Hero = memo(() => {
               transition={{ duration: 2, ease: [0.22, 1, 0.36, 1], delay: 1.6 }}
             />
           </div>
-          <div style={{ fontFamily: "var(--font-vt323)", fontSize: "0.95rem", color: "var(--text-muted)", marginTop: 4, letterSpacing: "0.08em" }}>
+          <div
+            style={{
+              fontFamily: "var(--font-vt323)",
+              fontSize: "0.95rem",
+              color: "var(--text-muted)",
+              marginTop: 4,
+              letterSpacing: "0.08em",
+            }}
+          >
             {heroData.xpBar.progressText}
           </div>
         </div>
-
       </div>
 
       {/* Ground row */}

--- a/src/data.ts
+++ b/src/data.ts
@@ -82,7 +82,7 @@ const heroData = {
     "block-dirt",
     "block-grass",
   ] as string[],
-  pixelName: "KEYYARD",
+  pixelName: "KEYYARD"  // display name kept; SEO H1 handled via aria-label in Hero.tsx,
   roleBadge: "Minecraft Developer & Software Engineer",
   storyHook: `In 2018, I started modding Minecraft from scratch — no tutorials, just curiosity and a text editor.<br/>By 2024, <strong>I contributed to the official <span class="hl-diamond">Minecraft × Cut The Rope crossover DLC</span></strong>, and my addons had been downloaded <span class="hl-gold">5M+ times</span> across the world.`,
   statCards: [

--- a/src/data.ts
+++ b/src/data.ts
@@ -82,7 +82,7 @@ const heroData = {
     "block-dirt",
     "block-grass",
   ] as string[],
-  pixelName: "KEYYARD"  // display name kept; SEO H1 handled via aria-label in Hero.tsx,
+  pixelName: "KEYYARD",
   roleBadge: "Minecraft Developer & Software Engineer",
   storyHook: `In 2018, I started modding Minecraft from scratch — no tutorials, just curiosity and a text editor.<br/>By 2024, <strong>I contributed to the official <span class="hl-diamond">Minecraft × Cut The Rope crossover DLC</span></strong>, and my addons had been downloaded <span class="hl-gold">5M+ times</span> across the world.`,
   statCards: [

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -10,16 +10,17 @@ class WebDocument extends Document {
           {/* SEO Enhancements */}
           <meta
             name="keywords"
-            content="Keyyard, Minecraft, Mods, Addons, Marketplace, Minecraft, Tree Capitator, Vein Miner, Actual Guns, MCPEDL, Modbay, PrestonPlayz, Official Minecraft Marketplace, Minecraft Developer, Portfolio, Game Design, Minecraft Bedrock"
+            content="Keyyard, Minecraft, Mods, Addons, Marketplace, Tree Capitator, Vein Miner, Actual Guns, MCPEDL, Modbay, PrestonPlayz, Official Minecraft Marketplace, Minecraft Developer, Portfolio, Game Design, Minecraft Bedrock"
           />
           <meta name="author" content="Keyyard" />
+          <meta name="robots" content="index, follow, max-snippet:-1, max-image-preview:large" />
 
           {/* Open Graph data */}
           <meta property="og:type" content="website" />
           <meta property="og:title" content="Keyyard | Minecraft Bedrock Developer" />
           <meta
             property="og:description"
-            content="Official Website of Keyyard, a Minecraft Bedrock Developer since 2018. Exploring high-quality mods, addons, and marketplace content like Cut the Rope × Minecraft DLC."
+            content="Microsoft Partner & Minecraft Bedrock Developer with 5M+ downloads. Creator of the Cut the Rope × Minecraft DLC, Actual Guns MCBE, and Productivitism — Life RPG on iOS."
           />
           <meta property="og:url" content="https://keyyard.xyz/" />
           <meta property="og:site_name" content="Keyyard" />
@@ -101,7 +102,10 @@ class WebDocument extends Document {
                       "TypeScript",
                       "Node.js",
                       "CLI Tooling",
-                      "Entity AI Development"
+                      "Entity AI Development",
+                      "iOS App Development",
+                      "Gamified Productivity",
+                      "Swift"
                     ],
                     "knowsLanguage": ["English", "Indonesian"],
                     "worksFor": [
@@ -109,12 +113,14 @@ class WebDocument extends Document {
                         "@type": "Organization",
                         "name": "Mushco",
                         "url": "https://www.mushco.games/"
-                      },
+                      }
+                    ],
+                    "sponsor": [
                       {
                         "@type": "Organization",
                         "name": "Mojang Studios",
                         "url": "https://www.minecraft.net",
-                        "description": "Official Minecraft DLC content partner."
+                        "description": "Official Minecraft Marketplace DLC content partner."
                       }
                     ],
                     "alumniOf": [

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -13,11 +13,17 @@ class WebDocument extends Document {
             content="Keyyard, Minecraft, Mods, Addons, Marketplace, Tree Capitator, Vein Miner, Actual Guns, MCPEDL, Modbay, PrestonPlayz, Official Minecraft Marketplace, Minecraft Developer, Portfolio, Game Design, Minecraft Bedrock"
           />
           <meta name="author" content="Keyyard" />
-          <meta name="robots" content="index, follow, max-snippet:-1, max-image-preview:large" />
+          <meta
+            name="robots"
+            content="index, follow, max-snippet:-1, max-image-preview:large"
+          />
 
           {/* Open Graph data */}
           <meta property="og:type" content="website" />
-          <meta property="og:title" content="Keyyard | Minecraft Bedrock Developer" />
+          <meta
+            property="og:title"
+            content="Keyyard | Minecraft Bedrock Developer"
+          />
           <meta
             property="og:description"
             content="Microsoft Partner & Minecraft Bedrock Developer with 5M+ downloads. Creator of the Cut the Rope × Minecraft DLC, Actual Guns MCBE, and Productivitism — Life RPG on iOS."
@@ -27,16 +33,25 @@ class WebDocument extends Document {
           <meta property="og:image" content="https://keyyard.xyz/keyyard.png" />
           <meta property="og:image:width" content="1200" />
           <meta property="og:image:height" content="630" />
-          <meta property="og:image:alt" content="Keyyard — Minecraft Bedrock Developer" />
+          <meta
+            property="og:image:alt"
+            content="Keyyard — Minecraft Bedrock Developer"
+          />
 
           {/* Twitter Card data */}
           <meta name="twitter:card" content="summary_large_image" />
-          <meta name="twitter:title" content="Keyyard | Minecraft Bedrock Developer" />
+          <meta
+            name="twitter:title"
+            content="Keyyard | Minecraft Bedrock Developer"
+          />
           <meta
             name="twitter:description"
             content="Official Website of Keyyard, a Minecraft Bedrock Developer since 2018. Microsoft Partner, DLC Developer, and creator of Actual Guns MCBE."
           />
-          <meta name="twitter:image" content="https://keyyard.xyz/keyyard.png" />
+          <meta
+            name="twitter:image"
+            content="https://keyyard.xyz/keyyard.png"
+          />
           <meta name="twitter:creator" content="@keyyard" />
 
           {/* Favicon */}
@@ -51,7 +66,11 @@ class WebDocument extends Document {
 
           {/* Fonts */}
           <link rel="preconnect" href="https://fonts.googleapis.com" />
-          <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
+          <link
+            rel="preconnect"
+            href="https://fonts.gstatic.com"
+            crossOrigin="anonymous"
+          />
           <link
             href="https://fonts.googleapis.com/css2?family=Press+Start+2P&family=VT323&family=Outfit:wght@300;400;500;600;700&display=swap"
             rel="stylesheet"
@@ -73,30 +92,32 @@ class WebDocument extends Document {
                   {
                     "@type": "WebSite",
                     "@id": "https://keyyard.xyz/#website",
-                    "name": "Keyyard",
-                    "url": "https://keyyard.xyz"
+                    name: "Keyyard",
+                    url: "https://keyyard.xyz",
                   },
                   {
                     "@type": "ProfilePage",
                     "@id": "https://keyyard.xyz/#profilepage",
-                    "url": "https://keyyard.xyz",
-                    "name": "Keyyard — Minecraft Bedrock Developer Portfolio",
-                    "isPartOf": { "@id": "https://keyyard.xyz/#website" },
-                    "mainEntity": { "@id": "https://keyyard.xyz/#person" }
+                    url: "https://keyyard.xyz",
+                    name: "Keyyard — Minecraft Bedrock Developer Portfolio",
+                    isPartOf: { "@id": "https://keyyard.xyz/#website" },
+                    mainEntity: { "@id": "https://keyyard.xyz/#person" },
                   },
                   {
                     "@type": "Person",
                     "@id": "https://keyyard.xyz/#person",
-                    "name": "Keyyard",
-                    "url": "https://keyyard.xyz",
-                    "image": {
+                    name: "Keyyard",
+                    url: "https://keyyard.xyz",
+                    image: {
                       "@type": "ImageObject",
-                      "url": "https://keyyard.xyz/keyyard.png",
-                      "contentUrl": "https://keyyard.xyz/keyyard.png"
+                      url: "https://keyyard.xyz/keyyard.png",
+                      contentUrl: "https://keyyard.xyz/keyyard.png",
                     },
-                    "jobTitle": "Minecraft Bedrock Developer & Fullstack Engineer",
-                    "description": "Minecraft Bedrock Developer since 2018, specializing in high-performance scripting, entity AI, and official marketplace content. Creator of Actual Guns MCBE, Tree Capitator, and collaborator on the Cut the Rope × Minecraft DLC.",
-                    "knowsAbout": [
+                    jobTitle:
+                      "Minecraft Bedrock Developer & Fullstack Engineer",
+                    description:
+                      "Minecraft Bedrock Developer since 2018, specializing in high-performance scripting, entity AI, and official marketplace content. Creator of Actual Guns MCBE, Tree Capitator, and collaborator on the Cut the Rope × Minecraft DLC.",
+                    knowsAbout: [
                       "Minecraft Bedrock Scripting",
                       "Game Mechanics Design",
                       "TypeScript",
@@ -105,39 +126,40 @@ class WebDocument extends Document {
                       "Entity AI Development",
                       "iOS App Development",
                       "Gamified Productivity",
-                      "Swift"
+                      "Swift",
                     ],
-                    "knowsLanguage": ["English", "Indonesian"],
-                    "worksFor": [
+                    knowsLanguage: ["English", "Indonesian"],
+                    worksFor: [
                       {
                         "@type": "Organization",
-                        "name": "Mushco",
-                        "url": "https://www.mushco.games/"
-                      }
+                        name: "Mushco",
+                        url: "https://www.mushco.games/",
+                      },
                     ],
-                    "sponsor": [
+                    sponsor: [
                       {
                         "@type": "Organization",
-                        "name": "Mojang Studios",
-                        "url": "https://www.minecraft.net",
-                        "description": "Official Minecraft Marketplace DLC content partner."
-                      }
+                        name: "Mojang Studios",
+                        url: "https://www.minecraft.net",
+                        description:
+                          "Official Minecraft Marketplace DLC content partner.",
+                      },
                     ],
-                    "alumniOf": [
-                      { "@type": "Organization", "name": "Bedrock OSS" }
+                    alumniOf: [
+                      { "@type": "Organization", name: "Bedrock OSS" },
                     ],
-                    "sameAs": [
+                    sameAs: [
                       "https://twitter.com/keyyard",
                       "https://github.com/keyyard",
                       "https://www.youtube.com/@keyyard",
                       "https://mcpedl.com/user/keyyard/",
                       "https://modbay.org/user/Keyyard/",
                       "https://www.bedrockexplorer.com/@g2crafted",
-                      "https://www.npmjs.com/package/create-mc-bedrock"
-                    ]
-                  }
-                ]
-              })
+                      "https://www.npmjs.com/package/create-mc-bedrock",
+                    ],
+                  },
+                ],
+              }),
             }}
           />
         </Head>


### PR DESCRIPTION
## SEO Fixes for keyyard.xyz

### Changes

**H1 Keyword Injection**
- Visual H1 stays as `KEYYARD` (pixel name unchanged)
- Added `.sr-only` span inside H1 so search engines read: *"KEYYARD — Minecraft Bedrock Developer, iOS Engineer & Microsoft Marketplace Partner"*
- H1 is the single most important on-page SEO signal

**Meta Description**
- Old: *"Exploring high-quality mods..."* (weak opener)
- New: *"Microsoft Partner & Minecraft Bedrock Developer with 5M+ downloads. Creator of the Cut the Rope × Minecraft DLC, Actual Guns MCBE, and Productivitism — Life RPG on iOS."*

**Meta Robots**
- Added explicit `index, follow, max-snippet:-1, max-image-preview:large`

**Keywords Meta**
- Removed duplicate `Minecraft` entry

**JSON-LD**
- Moved Mojang Studios from `worksFor` to `sponsor` (accurate — DLC partner, not employee)
- Added iOS App Development, Gamified Productivity, Swift to `knowsAbout`

**sr-only CSS utility class** added to App.css

**Fix:** removed inline comment in `data.ts` that broke object literal syntax and caused build failure